### PR TITLE
Update to the lowest version that includes a secure version of com.fasterxml.jackson.core:jackson-databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <module>exchange</module>
     </modules>
      <properties>
-        <jersey.version>2.24</jersey.version>
+        <jersey.version>2.30.1</jersey.version>
         <raml.generator.version>0.12-SNAPSHOT</raml.generator.version>
     </properties>
 


### PR DESCRIPTION
In order to avoid shipping artifacts that contain high-security vulnerabilities, an update was required.
The proposed jersey version is the earliest version that depends on a Jackson Databind version that has no vulnerability (version 2.10.1).