### PR TITLE
Add `jersey-hk2` for Jersey 2.26+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
             <version>${jersey.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
             <version>${jersey.version}</version>


### PR DESCRIPTION
As stated on the [Jersey 2.26 release notes](https://eclipse-ee4j.github.io/jersey.github.io/release-notes/2.26.html) there was a change around the Dependency Injection mechanism used by Jersey. On previous versions it was tightly coupled to HK2. Some changes were started on this version to allow other implementations (like CDI or Guice) to be used.

Currently, the only official implementations are [HK2 and CDI](https://github.com/eclipse-ee4j/jersey/tree/bb65db41830a2308a1c83ba90ec0b0dd804fd8c3/inject).
There are some unofficial implementations attempts with [Guice](https://github.com/eclipse-ee4j/jersey/issues/3692).

If no implementation exists the following exception is thrown:
```
java.lang.IllegalStateException: InjectionManagerFactory not found.
```

As the HK2 was the one that was previously used, we added `jersey-hk2` in order to keep it as it was.